### PR TITLE
Fix config file loading from $HOME

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -25,6 +25,7 @@ backy2 will per default search the following locations for configuration files:
 * /etc/backy/backy.cfg
 * /etc/backy/conf.d/*
 * ~/.backy.cfg
+* ~/backy.cfg
 
 In case multiple of these configurations exist, they are read in this order (later options
 overwrite earier ones).

--- a/src/backy2/config.py
+++ b/src/backy2/config.py
@@ -66,8 +66,8 @@ class Config(object):
         sources = ['/etc/{name}.cfg'.format(name=conf_name)]
         sources.append('/etc/{name}/{name}.cfg'.format(name=conf_name))
         sources.extend(sorted(glob.glob('/etc/{name}/conf.d/*'.format(name=conf_name))))
-        sources.append('~/.{name}.cfg'.format(name=conf_name))
-        sources.append(expanduser('{name}.cfg'.format(name=conf_name)))
+        sources.append(expanduser('~/.{name}.cfg'.format(name=conf_name)))
+        sources.append(expanduser('~/{name}.cfg'.format(name=conf_name)))
         return sources
 
     def _getany(self, method, option, default):

--- a/src/backy2/config.py
+++ b/src/backy2/config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
 
-from configparser import SafeConfigParser, NoSectionError, NoOptionError
+from configparser import ConfigParser, NoSectionError, NoOptionError
 from io import StringIO
 from os.path import expanduser
 import glob
@@ -51,16 +51,16 @@ class Config(object):
         if section is not None:
             self.SECTION = section
         if cfg is None:
-            self.cp = SafeConfigParser()
-            self.cp.readfp(StringIO(default_config))
+            self.cp = ConfigParser()
+            self.cp.read_file(StringIO(default_config))
             if conf_name:
                 sources = self._getsources(conf_name)
                 self.cp.read(sources)
             for fp in extra_sources:
-                self.cp.readfp(fp)
+                self.cp.read_file(fp)
         else:
-            self.cp = SafeConfigParser()
-            self.cp.readfp(StringIO(cfg))
+            self.cp = ConfigParser()
+            self.cp.read_file(StringIO(cfg))
 
     def _getsources(self, conf_name):
         sources = ['/etc/{name}.cfg'.format(name=conf_name)]


### PR DESCRIPTION
This fixes configuration file loading from the user's home directory. I'm not sure about the original intention on the last sources.append(): either the expanduser() has to go or the ~ has to be added to the string literal like in this PR.

Python 3.2 was released  in 2011. I think it should be okay to require it.
