### PR TITLE
Fix s3.py to use the existing bucket

### DIFF
--- a/src/backy2/data_backends/s3.py
+++ b/src/backy2/data_backends/s3.py
@@ -57,6 +57,7 @@ class DataBackend(_DataBackend):
             self.bucket = self.conn.create_bucket(bucket_name)
         except boto.exception.S3CreateError:
             # exists...
+            self.bucket = self.conn.get_bucket(bucket_name)
             pass
         except OSError as e:
             # no route to host


### PR DESCRIPTION
It was not possible to use s3, because the create bucket failed (already exist), but the existing bucket was not used.