### PR TITLE
du sql query: eliminate use of count(a.*)

### DIFF
--- a/src/backy2/meta_backends/sql.py
+++ b/src/backy2/meta_backends/sql.py
@@ -254,7 +254,7 @@ class MetaBackend(_MetaBackend):
 
         # find real blocks
         statement = text("""
-            select a.uid, a.size, count(a.*) own_shared,
+            select a.uid, a.size, count(a.uid own_shared,
                 (select count(*) cnt from blocks where uid=a.uid) shared
             from blocks a
                 where a.version_uid=:version_uid


### PR DESCRIPTION
The particular syntax count(a.*) in this query doesn't parse
on mariadb (or, presumably, mysql).  Counting a.uid is equivalent;
we can be confident that there aren't any rows without uid
set because the query includes 'a.uid is not NULL'.

Addresses https://github.com/wamdam/backy2/issues/71


Here are examples in mariadb:

mysql:galera_backup@localhost [eqiad1_ceph_backy]> select a.uid, a.size, count(a.*) from blocks a where a.version_uid="bc7eae94-d8f8-11ea-8823-f0921c05f570" and a.uid is not NULL;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '*) from blocks a where a.version_uid="bc7eae94-d8f8-11ea-8823-f0921c05f570" and ' at line 1

mysql:galera_backup@localhost [eqiad1_ceph_backy]> select a.uid, a.size, count(a.uid) own_shared,                 (select count(*) cnt from blocks where uid=a.uid) shared             from blocks a                 where a.version_uid="bc7eae94-d8f8-11ea-8823-f0921c05f570"                 and a.uid is not NULL             group by a.uid, a.size limit 2;
+----------------------------------+---------+------------+--------+
| uid                              | size    | own_shared | shared |
+----------------------------------+---------+------------+--------+
| 000f3a5685vDGo3bcSJEXE4i34ioQHAd | 4194304 |          1 |      4 |
| 009da580dfystrfRKiYZMEBX4dFbbSw6 | 4194304 |          1 |      4 |
+----------------------------------+---------+------------+--------+
2 rows in set (0.033 sec)