### PR TITLE
Remove misleading documentation in backy.cfg

### DIFF
--- a/etc/backy.cfg
+++ b/etc/backy.cfg
@@ -39,7 +39,6 @@ deduplication: 1
 # The key must be in hex notation (which the above command will output).
 # Here is an example. Create your own and make sure you save it elsewhere. If
 # this key is lost, all your backups are too.
-# If unset, no encryption will be used.
 #encryption_key: decafbaddecafbaddecafbaddecafbaddecafbaddecafbaddecafbaddecafbad
 
 # Encryption versions:


### PR DESCRIPTION
If encryption_key is unset when encryption_version > 0, the following happens (which is good):

```
# backy2 ls
    INFO: [backy2.logging] $ /usr/bin/backy2 ls
Traceback (most recent call last):
  File "/usr/lib/python3.8/configparser.py", line 789, in get
    value = d[option]
  File "/usr/lib/python3.8/collections/__init__.py", line 898, in __getitem__
    return self.__missing__(key)            # support subclasses that define __missing__
  File "/usr/lib/python3.8/collections/__init__.py", line 890, in __missing__
    raise KeyError(key)
KeyError: 'encryption_key'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/backy2", line 11, in <module>
    load_entry_point('backy2==2.13.8', 'console_scripts', 'backy2')()
  File "/usr/lib/python3/dist-packages/backy2/scripts/backy.py", line 753, in main
    commands = Commands(args.machine_output, args.skip_header, args.human_readable, Config)
  File "/usr/lib/python3/dist-packages/backy2/scripts/backy.py", line 31, in __init__
    self.backy = backy_from_config(Config)
  File "/usr/lib/python3/dist-packages/backy2/utils.py", line 100, in backy_from_config
    encryption_key = config_DEFAULTS.get('encryption_key', None)  # if None then version=0 will be used (no encryption)
  File "/usr/lib/python3/dist-packages/backy2/config.py", line 81, in get
    return self._getany(self.cp.get, option, default)
  File "/usr/lib/python3/dist-packages/backy2/config.py", line 74, in _getany
    return method(self.SECTION, option)
  File "/usr/lib/python3.8/configparser.py", line 792, in get
    raise NoOptionError(option, section)
configparser.NoOptionError: No option 'encryption_key' in section: 'DEFAULTS'
```